### PR TITLE
feat: Introduce `RawMidi` and `Midi` types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "miami"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "miami"
 version = "0.1.2"
 authors = ["BradenEverson <bradeneverson@gmail.com>"]
-description = "Minimal dependency MIDI file format parser"
+description = "Minimal dependency MIDI file format parser and writer"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/BradenEverson/miami"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miami"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["BradenEverson <bradeneverson@gmail.com>"]
 description = "Minimal dependency MIDI file format parser"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -35,12 +35,17 @@ let mut data = "path/to/midi/file.mid"
     .get_midi_bytes()
     .expect("Failed to load MIDI file");
 
-while let Some(parsed) = data
-    .read_chunk_data_pair()
-    .map(|val| ParsedChunk::try_from(val))
-{
-    println!("{parsed:?}");
+let midi = RawMidi::try_from_midi_stream(data).expect("Parse data as a MIDI stream");
+
+for chunk in midi.chunks.iter() {
+    println!("{chunk:?}");
 }
+```
+
+A `RawMidi` can also be sanitized and upgraded into a `Midi` struct that contains a single header and a subsequent list of tracks:
+
+```rust
+let sanitized: Midi = midi.check_into_midi().expect("Upgrade to Midi");
 ```
 
 Writing a set of ParsedChunks to a file:

--- a/examples/chunk_read.rs
+++ b/examples/chunk_read.rs
@@ -1,19 +1,17 @@
 //! Example program that reads the entirety of a MIDI file as raw chunks
 
-use miami::{
-    chunk::ParsedChunk,
-    reader::{MidiReadable, MidiStream},
-};
+use miami::{reader::MidiReadable, Midi, RawMidi};
 
 fn main() {
-    let mut data = "test/test.mid"
+    let data = "test/test.mid"
         .get_midi_bytes()
         .expect("Get `run.midi` file and stream bytes");
 
-    while let Some(parsed) = data
-        .read_chunk_data_pair()
-        .map(|val| ParsedChunk::try_from(val))
-    {
-        println!("{parsed:?}")
+    let midi = RawMidi::try_from_midi_stream(data).expect("Parse data as a MIDI stream");
+    let sanitized_midi: Midi = midi.try_into().expect("Upgrade into sanitized format");
+
+    println!("Header: {:?}", sanitized_midi.header);
+    for chunk in sanitized_midi.tracks.iter() {
+        println!("Track: {chunk:?}");
     }
 }

--- a/examples/chunk_read.rs
+++ b/examples/chunk_read.rs
@@ -8,7 +8,9 @@ fn main() {
         .expect("Get `run.midi` file and stream bytes");
 
     let midi = RawMidi::try_from_midi_stream(data).expect("Parse data as a MIDI stream");
-    let sanitized_midi: Midi = midi.try_into().expect("Upgrade into sanitized format");
+    let sanitized_midi: Midi = midi
+        .check_into_midi()
+        .expect("Upgrade into sanitized format");
 
     println!("Header: {:?}", sanitized_midi.header);
     for chunk in sanitized_midi.tracks.iter() {

--- a/examples/copy.rs
+++ b/examples/copy.rs
@@ -1,25 +1,23 @@
 //! Example program that reads the entirety of a MIDI file as raw chunks and writes it to a second
 //! file to test byte writing
 
-use miami::{
-    chunk::ParsedChunk,
-    reader::{MidiReadable, MidiStream},
-    writer::MidiWriteable,
-};
+use miami::{reader::MidiReadable, writer::MidiWriteable};
+use miami::{Midi, RawMidi};
 use std::fs::File;
 use std::io::Write;
 
 fn main() {
     let mut output = File::create("test/test_run.mid").expect("Create new output file");
-    let mut data = "test/run.mid"
+    let data = "test/run.mid"
         .get_midi_bytes()
         .expect("Get `run.midi` file and stream bytes");
 
-    while let Some(Ok(parsed)) = data
-        .read_chunk_data_pair()
-        .map(|val| ParsedChunk::try_from(val))
-    {
-        let bytes = parsed.to_midi_bytes();
-        output.write(&bytes).expect("Failed to write bytes");
-    }
+    let midi: Midi = RawMidi::try_from_midi_stream(data)
+        .expect("Parse data as a MIDI stream")
+        .try_into()
+        .expect("Sanitize MIDI into formatted MIDI");
+
+    output
+        .write_all(&midi.to_midi_bytes())
+        .expect("Failed to write bytes");
 }

--- a/examples/copy.rs
+++ b/examples/copy.rs
@@ -14,7 +14,7 @@ fn main() {
 
     let midi: Midi = RawMidi::try_from_midi_stream(data)
         .expect("Parse data as a MIDI stream")
-        .try_into()
+        .check_into_midi()
         .expect("Sanitize MIDI into formatted MIDI");
 
     output


### PR DESCRIPTION
This PR introduces the `RawMidi` and `Midi` types, a nicer way to handle MIDI streams than the previous methods necessary. You can now attempt constructing a `RawMidi` from any MidiStreamable type. 

`RawMidi` contains only a `Vec<ParsedChunk>` and therefore could be malformed or invalid MIDI. Therefore we can try upgrading it into a `Midi` struct that enforces a single starting header chunk and *only* track chunks thereafter.

These changes have been updated in the docs and the examples, showing a much more concise and nice looking API :)